### PR TITLE
Fix append dbus message for String Variant

### DIFF
--- a/src/dbus_message.cpp
+++ b/src/dbus_message.cpp
@@ -108,7 +108,7 @@ void DBusMessage::append(const Variant &p_value) {
 			ERR_FAIL_MSG("Unsupported type");
 			break;
 	}
-	ERR_FAIL_COND_MSG(_r < 0, "Failed to append value");
+	ERR_FAIL_COND_MSG(_r < 0, String("Failed to append value: ") + strerror(-_r));
 }
 
 void DBusMessage::append_all(const Array &p_values) {

--- a/src/dbus_message.cpp
+++ b/src/dbus_message.cpp
@@ -101,7 +101,7 @@ void DBusMessage::append(const Variant &p_value) {
 		APPEND_VARIANT(INT, int64_t)
 		APPEND_VARIANT(FLOAT, double)
 		case Variant::Type::STRING: {
-			_r = sd_bus_message_append_basic(_message, p_value.get_type(), String(p_value).utf8().get_data());
+			_r = sd_bus_message_append_basic(_message, variant_to_specifier(p_value.get_type()), String(p_value).utf8().get_data());
 			break;
 		}
 		default:


### PR DESCRIPTION
Hey thanks for this add-on!

I figured `sd_bus_message_append_basic` was complaining because of an invalid argument when I tried appending strings, turns out the godot Variant enum value was passed rather than its dbus char specifier counterpart.
Added just a bit a logging to find out about it.

Reading string arguments seems to work just fine.

I got more changes, such as support String Name variant, and reading dbus message container arguments, but those are quite a mess atm so that's it for now.